### PR TITLE
fix bug to support python3

### DIFF
--- a/library/parse_dotenv_sample.py
+++ b/library/parse_dotenv_sample.py
@@ -64,7 +64,7 @@ def main():
     dotenv_template_path = None
     template = _parse_dotenv_sample(module.params['dotenv_sample_path'], module.params['env_dict_varname'])
     with NamedTemporaryFile(delete=False) as f:
-      f.write(template)
+      f.write(template.encode('utf8'))
       dotenv_template_path = f.name
     module.exit_json(changed=True, dotenv_template_path=dotenv_template_path)
   except IOError as err:


### PR DESCRIPTION
When writing to a file, the data must be encoded in UTF-8 in python3 and not string.